### PR TITLE
add privacy policy page

### DIFF
--- a/peoples_budget/templates/home.html
+++ b/peoples_budget/templates/home.html
@@ -21,12 +21,13 @@
     <p>This project is designed to make the budget for the City of Cleveland easier to understand. Its agenda is
         to make it clear where the money is going, and to provide people with the opportunity to see the
         difference between their budget priorities and their city government’s priorities.</p>
-	<p>The mayor's 2021 budget estimate is <a href=https://www.city.cleveland.oh.us/sites/default/files/forms_publications/2021MayorsEstimate.pdf>available here</a>. This website examines only the "general fund." Essential parts of life—schools, water, roads, public housing, etc.—each have separate budgets based on different revenue streams that do not compete for funding with the budget items above. Moreover, this project does not examine the legislative or judicial budgets. Determining an appropriate cost for running city council and the court system is complex beyond this project's scope. Instead, the budget captured here is where all the action is. </p>
+	<p>The <a href=https://www.city.cleveland.oh.us/sites/default/files/forms_publications/2021MayorsEstimate.pdf>mayor's 2021 budget estimate is </a> now available. This website examines only the "general fund." Essential parts of life—schools, water, roads, public housing, etc.—each have separate budgets based on different revenue streams that do not compete for funding with the budget items above. Moreover, this project does not examine the legislative or judicial budgets. Determining an appropriate cost for running city council and the court system is complex beyond this project's scope. Instead, the budget captured here is where all the action is. </p>
     <p>Refund Cleveland is a collaborative and community-led effort to design a city budget that centers around
         the values, needs, and priorities of our community. We want to thank <a target="_blank"
                                                                                 href="https://www.opencleveland.org/">Open
             Cleveland</a> and all of their
         volunteers for their help and guidance in bringing this project to life.</p>
+    <p>We value your privacy and <a href="/privacy-policy">read how your information will be shared </a>. </p>
     {#        </div>#}
     {#    </div>#}
 

--- a/peoples_budget/templates/privacy-policy.html
+++ b/peoples_budget/templates/privacy-policy.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+
+    <div id="header-info">
+        <h1>Privacy Policy</h1>
+    </div>
+
+    We at Open Cleveland respect your privacy and collect as little as information as possible so that your priorities will be shared with your city councilperson. 
+
+    <p>We collect: </p>
+    <ul>
+    <li>Your email address </li>
+    <li>Your ward</li>
+    <li>Your budget priorities (the percentage values you allocate to each category)</li>
+    <li>The time and date when you submitted a budget </li>
+    </ul>
+
+<p>What we share: </p>
+    <ul>
+    <li>Your email address</li>
+    <li>Your totals will be shared in sum </li>
+</ul>
+    <p>Who it will be shared with: </p>
+    
+    The councilperson from the ward that you share with us.
+    
+    <p>Your email address will be shared with your councilperson in the event they wish to contact you. Collecting an email address also allows us to limit the number of submissions per person. </p>
+    
+     <p>We cannot guarantee your information will not be incidentally identified (if you are the only person in your ward to submit a result, for example). </p>
+    
+     <p>We will not sell or share your information with any other party except what was mentioned above and we will not keep it after the project is over (July 24, 2021). </p>
+    
+    <p>What we do NOT collect: </p>
+    
+    We do not collect any other information about your visit to the website, such as:
+    <li>Domain from which you access the Internet</li>
+    <li>Operating system on your computer and information about the browser you used when visiting the site</li>
+    <li>Pages you visited</li>
+    <li>Address of the website that connects you to the Site (such as google.com or bing.com)</li>
+    
+
+    {#        </div>#}
+    {#    </div>#}
+
+
+{% endblock content %}
+
+{% block footer_scripts %}
+
+{% endblock footer_scripts %}

--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -144,3 +144,10 @@ def send_email(submitter_email, id):
 			"text": f"Thank you for submitting your budget proposal for the 2021 City of Cleveland Budget!\n"
                     f"View or share your budget here: https://www.refundcleveland.com/{id}/view\n\n"
                     f"Brought to you by your friends at Open Cleveland! https://www.opencleveland.org"})
+                    
+                    
+def privacy_policy(request):
+    return render(request, 'privacy-policy.html', {
+        'home': True,
+        'body_classes': 'privacy-policy'
+    })

--- a/refund_cleveland/urls.py
+++ b/refund_cleveland/urls.py
@@ -24,5 +24,6 @@ urlpatterns = [
     path('submit/', views.submit_budget, name='submit_budget'),
     path('store-data/', views.store_data, name='store_data'),
     path('<budget_id>/view/', views.view_budget, name='view_budget'),
-    path('lookup_address', views.lookup_address, name='lookup_address')
+    path('lookup_address', views.lookup_address, name='lookup_address'),
+    path('privacy-policy', views.privacy_policy, name='privacy_policy')
 ]


### PR DESCRIPTION
Added a privacy page; there's a link for it on the bottom of the homepage for now; 

I don't quite know what I'm doing here, so if someone could look it over, that'd be great, in particular this line whether 
'home should be set to true https://github.com/opencleveland/refundcleveland/pull/67/files#diff-5d95c6257a0cb0a603744801035d0297958fdc568d802d906ee45fa3462ad89eR151 
(I copied that from the home view here - https://github.com/opencleveland/refundcleveland/blob/8f39c61d8cd3b9b220abb0970550c27caa158aa4/peoples_budget/views.py#L23