### PR TITLE
fix #68, append cleveland ohio to geocoding query, improving results

### DIFF
--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -116,7 +116,7 @@ def view_budget(request, budget_id):
 
 def lookup_address(request):
     body = json.loads(request.body)
-    address = body['address']
+    address = body['address'] + 'Cleveland Ohio'
 
     query = "https://civicinfo.googleapis.com/civicinfo/v2/representatives?address=" + urllib.parse.quote_plus(address) + "&includeOffices=true&levels=locality&key="+ GOOGLE_API_KEY
 


### PR DESCRIPTION
appending cleveland ohio to the address query increased the accuracy of the address results. 

in #68, several addresses inputted were not returning any response or a 500 error. 
I appended Cleveland Ohio to the address query; and in all 5 of those cases mention in 68, the correct ward is returned. 

With geocoding (taking an address and putting into latitude and longitude), there's always tons of edge cases and difficulties so there still may be some instances where an expected address value doesn't return an accurate result (or any result at all!) but given our timeline, this should solve a majority of the issues that we experienced. 