### PR TITLE
Match bar padding on view page with change page

### DIFF
--- a/static/js/view-budget.js
+++ b/static/js/view-budget.js
@@ -20,9 +20,9 @@
     }
 
     const MULTIPLIER = 2,  // add height to bars
-        SHIFT = 2,  // bar height when data is 0
+        SHIFT = 40,  // bar height when data is $0
         margin = {top: 0, right: 0, bottom: 0, left: 0},
-        height = 215 - margin.top - margin.bottom + SHIFT,
+        height = 230 - margin.top - margin.bottom + SHIFT,
         colors = get_bar_colors();
 
     // Select container div


### PR DESCRIPTION
This is necessary (for now) due to where the dollar amounts are displayed. If a user allocated $0 to a category, the bar would be too thin for the dollar amount to display correctly.