### PR TITLE
Revert scale to match home page, remove dollars

### DIFF
--- a/static/js/view-budget.js
+++ b/static/js/view-budget.js
@@ -15,14 +15,14 @@
 
     let categories = data.fund_structure;
 
-    if (!data.hasOwnProperty('total')) {
-        data.total = 510657654;
-    }
+    // if (!data.hasOwnProperty('total')) {
+    //     data.total = 510657654;
+    // }
 
     const MULTIPLIER = 2,  // add height to bars
-        SHIFT = 40,  // bar height when data is $0
+        SHIFT = 2,  // bar height when data is $0
         margin = {top: 0, right: 0, bottom: 0, left: 0},
-        height = 230 - margin.top - margin.bottom + SHIFT,
+        height = 215 - margin.top - margin.bottom + SHIFT,
         colors = get_bar_colors();
 
     // Select container div
@@ -61,7 +61,7 @@
 
     // Add text elements to SVG to display bar totals
     let bar_totals = svgs.append("text").style("opacity", 0);
-    let bar_totals_dollars = svgs.append("text").style("opacity", 0);
+    // let bar_totals_dollars = svgs.append("text").style("opacity", 0);
 
     // Animate in bar totals on load
     bar_totals.html(d => Math.round(d.user_percentage) + "%")
@@ -72,17 +72,17 @@
         .duration(1500)
         .ease(d3.easeCubicOut);
 
-    // Animate in bar dollar amounts on load
-    bar_totals_dollars.html(d => "$" + add_commas(Math.round(d.user_percentage/100 * data.total)))
-        .attr("y", d => height - 5)
-        .attr("fill", "#fff")
-        .attr("x", 2)
-        .transition()
-        .attr("class", "dollar-amounts")
-        .style("opacity", 1)
-        .delay(650)
-        .duration(1800)
-        .ease(d3.easeCubicOut);
+    // // Animate in bar dollar amounts on load
+    // bar_totals_dollars.html(d => "$" + add_commas(Math.round(d.user_percentage/100 * data.total)))
+    //     .attr("y", d => height - 5)
+    //     .attr("fill", "#fff")
+    //     .attr("x", 2)
+    //     .transition()
+    //     .attr("class", "dollar-amounts")
+    //     .style("opacity", 1)
+    //     .delay(650)
+    //     .duration(1800)
+    //     .ease(d3.easeCubicOut);
 
     // Display line items below each bar
     bar_divs.append("div")


### PR DESCRIPTION
I commented out the sections that display the actual dollar amounts so that we can match the D3 scale to the one on the home page. If we come up with a better place to display them (that isn't dependent on having a certain bar height), they could be re-added.