### PR TITLE
Added Understanding the Budget page

### DIFF
--- a/peoples_budget/templates/base.html
+++ b/peoples_budget/templates/base.html
@@ -45,6 +45,7 @@
                     <li class="{% if home %}active{% endif %}"><a href="/">Home</a></li>
                     <li class="{% if change_budget %}active{% endif %}"><a href="/change-the-budget">Change the
                         budget</a></li>
+                    <li class="{% if understanding_the_budget %}active{% endif %}"><a href="/understanding-the-budget">Understanding the Budget</a></li>
                 </ul>
             </nav>
 
@@ -58,8 +59,8 @@
 
         <ul id="mobile_menu">
             <li class="{% if home %}active{% endif %}"><a href="/">Home</a></li>
-            <li class="{% if change_budget %}active{% endif %}"><a href="/change-the-budget">Change the
-                budget</a></li>
+            <li class="{% if change_budget %}active{% endif %}"><a href="/change-the-budget">Change the budget</a></li>
+            <li class="{% if understanding_the_budget %}active{% endif %}"><a href="/understanding-the-budget">Understanding the Budget</a></li>
         </ul>
     </header>
 

--- a/peoples_budget/templates/home.html
+++ b/peoples_budget/templates/home.html
@@ -4,15 +4,14 @@
 {% block content %}
 
     <div id="header-info">
-        <h1>Mayor Jackson's 2021 General Fund Proposal</h1>
+        <h1>Mayor Bibb's 2022 General Fund Proposal</h1>
     </div>
 
     <div id="budget_visualization"></div>
 
     <a id="submit_btn" href="/change-the-budget">Change The Budget</a>
 
-    <p>The residents of Cleveland have no public input into their city's budget. There are no budget town halls,
-        no public comment sessions, no way for the residents of Cleveland to discuss with their elected officials what the
+    <p>The residents of Cleveland have little public input into their city's budget. There is no participatory budgeting program, no budget town hall and few opportunities for the residents of Cleveland to discuss with their elected officials what the
         spending priorities should be in their community.</p>
     <p>This project is designed to make the budget for the City of Cleveland easier to understand. Its agenda is
         to make it clear where the money is going, and to provide people with the opportunity to see the

--- a/peoples_budget/templates/understanding-the-budget.html
+++ b/peoples_budget/templates/understanding-the-budget.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block content %}
+    <div class="understanding_the_budget">
+        <div id="header-info">
+            <h1>Here's what you need to know about the 2022 General Budget</h1>
+            <h3>A guide and glossary created by the Cleveland Documenters</h3>
+        </div>
+<p>Cleveland is required by law each year to pass a balanced budget, meaning the city can&rsquo;t spend more money than it takes in.&nbsp;</p>
+<p><strong>Here&rsquo;s how the process works:</strong></p>
+<ul>
+<li>The mayor sends City Council a document that summarizes the administration&rsquo;s budget recommendations. It has detailed information for each city department and city fund and includes estimates on how much money the city expects to collect through taxes and fees. This happens by Feb. 1 each year (yes, even during a pandemic!)</li>
+</ul>
+<ul>
+<li>City Council holds budget hearings in February. Council committee members discuss, debate and ask questions about spending priorities.&nbsp;</li>
+</ul>
+<ul>
+<li>Council members can agree to amend--change--portions of the budget recommended by the mayor.</li>
+</ul>
+<ul>
+<li>Council publicly shares its version of the budget, which is written into an ordinance or law that council votes on after hearings are completed. This is sometimes called the &ldquo;second reading&rdquo; of the budget.&nbsp;</li>
+</ul>
+<ul>
+<li>Council must wait at least 15 days after sharing the amended budget to do a &ldquo;third reading&rdquo; and vote to approve or not approve the budget.&nbsp;</li>
+</ul>
+<ul>
+<li>The city must approve a budget by April 1 of each year. After the budget is approved, it is posted online.&nbsp;</li>
+</ul>
+<ul>
+<li>At the end of the year, council reconciles the budget and decides whether to redistribute or save any money that was not spent.&nbsp;</li>
+</ul>
+<p>This year, the city will hold its budget hearings and deliberations in Council Chambers at City Hall. These hearings will also be livestreamed on <a href="http://www.tv20cleveland.com/">TV20</a> and on <a href="https://www.youtube.com/user/ClevelandCityCouncil">Council&rsquo;s YouTube channel.</a></p>
+<p>Mayor Frank Jackon explained his budget priorities for 2021 in this <a href="https://www.facebook.com/CityofCleveland/videos/407270510356337">Facebook Live video.&nbsp;</a></p>
+<p><strong>What is the purpose of the budget?</strong></p>
+<p>The budget tells residents what money the city is collecting and how it is being spent. The budget also clarifies what city leaders&rsquo; priorities are. The Budget Book breaks the spending and priorities down by department (the highest level of organization) and by division (different sections of the departments.) City departments have directors and divisions have commissioners.&nbsp;</p>
+<p>In the Budget Book, you can see priorities laid out for each department.&nbsp;</p>
+<p>Find the current Mayor&rsquo;s Estimate for the budget <a href="http://www.city.cleveland.oh.us/sites/default/files/forms_publications/2021MayorsEstimate.pdf">here</a>.</p>
+<p>Find the Community Development Block Grant Fund budget <a href="https://www.dropbox.com/sh/o7f7e9j4za562z0/AACbmwhDrx3WhhSUQXaF3XPSa?dl=0">here.</a><br /><br /></p>
+<p>Find past Budget Books here:&nbsp;</p>
+<p><a href="https://www.clevelandohio.gov/sites/default/files/forms_publications/2021BudgetBook.pdf">2021 Budget Book</a></p>
+<p><a href="http://www.city.cleveland.oh.us/sites/default/files/forms_publications/2020BudgetBook.pdf">2020 Budget Book</a></p>
+<p><a href="http://www.city.cleveland.oh.us/sites/default/files/forms_publications/2019BudgetBook.pdf">2019 Budget Book</a></p>
+<p><a href="http://www.city.cleveland.oh.us/sites/default/files/forms_publications/2018BudgetBook.pdf">2018 Budget Book</a></p>
+<p><strong>How is the budget organized?</strong></p>
+<ul>
+<li>The two main parts are the <strong>Operating Budget</strong> and the <strong>Capital Budget</strong>. The Operating Budget is the money spent on things such as employees and supplies. The Capital Budget includes larger investments in buildings or street lights.&nbsp;</li>
+</ul>
+<ul>
+<li>The money that is spent comes from several buckets. The major funds include: General Fund, Special Revenue Funds, Enterprise Funds and the Agency Fund. See the glossary below for definitions of these terms.&nbsp;</li>
+</ul>
+<ul>
+<li>Money that the city receives from most federal and state grants is not included in the city budget funds because those grants are managed following different rules and often on a different schedule, or fiscal year.&nbsp;</li>
+</ul>
+<p><strong>Where does the money come from?</strong></p>
+<p>Cleveland collects money in the form of taxes: income taxes from paychecks of people who work and/or live in the city, and taxes and fees from businesses such as &ldquo;bed&rdquo; taxes from hotel rooms.&nbsp;</p>
+<p><strong>What is City Council's role?</strong></p>
+<p>The legislative body reviews, amends (changes) and approves the city budget.&nbsp;</p>
+<p><strong>Budget terms:</strong></p>
+<p>Take a look at our <a href="https://drive.google.com/drive/folders/1fljcArYE5vUPXQo4l7L3RI19CjG_WQrf?usp=sharing">glossary of budget terms</a> and feel free to use the cards and definitions in your live-twitter threads and notes.</p>
+<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQN6GnpNS2BLCwSjPLQ9tiX9L2_q2r3bwKj8OzdvheQEiNYyd65gHZSD3nm69jPoBDfhe_04VB3XjLE/embed?start=false&loop=true&delayms=3000" frameborder="0" width="480" height="299" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+        <div id="understanding_the_budget_legend"></div>
+        <div id="understanding_the_budget"></div>
+    </div>
+
+{% endblock content %}

--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -161,3 +161,10 @@ def privacy_policy(request):
         'home': True,
         'body_classes': 'privacy-policy'
     })
+
+def understanding_the_budget(request):
+    return render(request, 'understanding-the-budget.html', {
+        'home': True,
+        'body_classes': 'understanding_the_budget'
+    })
+

--- a/refund_cleveland/urls.py
+++ b/refund_cleveland/urls.py
@@ -25,5 +25,6 @@ urlpatterns = [
     path('store-data/', views.store_data, name='store_data'),
     path('<budget_id>/view/', views.view_budget, name='view_budget'),
     path('lookup_address', views.lookup_address, name='lookup_address'),
-    path('privacy-policy', views.privacy_policy, name='privacy_policy')
+    path('privacy-policy', views.privacy_policy, name='privacy_policy'),
+    path('understanding-the-budget/', views.understanding_the_budget, name='understanding_the_budget')
 ]


### PR DESCRIPTION
I added the explainer page "Understanding the Budget" to the site, where the Cleveland Documenters 2022 Budget Explainer and Budget Glossary live. 

I also updated the title and a few details on the home page (i.e. Jackson to Bibb). Numbers on the Home and Change the Budget pages are still not updated to reflect the 2022 Mayor's Estimate.