### PR TITLE
Updates for 2025

### DIFF
--- a/peoples_budget/templates/home.html
+++ b/peoples_budget/templates/home.html
@@ -4,7 +4,7 @@
 {% block content %}
 
     <div id="header-info">
-        <h1>Mayor Bibb's 2024 General Fund Proposal</h1>
+        <h1>Mayor Bibb's 2025 General Fund Proposal</h1>
     </div>
 
     <div id="budget_visualization"></div>
@@ -15,8 +15,8 @@
         spending priorities should be in their community. </p>
     <p>This project is designed to make the budget for the City of Cleveland easier to understand. Its agenda is
         to make it clear where the money is going, and to provide people with the opportunity to see the
-        difference between their budget priorities and their city government’s priorities.</p>
-	<p>The <a target="_blank" href="https://www.clevelandohio.gov/sites/clevelandohio/files/2024MayorsEstimate020124.pdf">Mayor's 2024 budget estimate</a> is now available. This website examines only the "general fund." Essential parts of life—schools, water, roads, public housing, etc.—each have separate budgets based on different revenue streams that do not compete for funding with the budget items above. Moreover, this project does not examine the legislative or judicial budgets. Determining an appropriate cost for running city council and the court system is complex beyond this project's scope. Instead, the budget captured here is where all the action is. </p>
+        difference between their budget priorities and their city government’s priorities.</p> 
+	<p>The <a target="_blank" href="https://www.clevelandohio.gov/sites/clevelandohio/files/finance-docs/documents/2025%20City%20of%20Cleveland%20Mayor's%20Estimate_FINAL.pdf">Mayor's 2025 budget estimate</a> is now available. This website examines only the "general fund." Essential parts of life—schools, water, roads, public housing, etc.—each have separate budgets based on different revenue streams that do not compete for funding with the budget items above. Moreover, this project does not examine the legislative or judicial budgets. Determining an appropriate cost for running city council and the court system is complex beyond this project's scope. Instead, the budget captured here is where all the action is. </p>
     <p>For more information about the City of Cleveland's budget process, please see the <a target="_blank" href="/understanding-the-budget">Understanding the Budget</a> page created and contributed by the Cleveland Documenters.</p>
     <p>Refund Cleveland is a collaborative and community-led effort to design a city budget that centers around
         the values, needs, and priorities of our community. We want to thank <a target="_blank"

--- a/peoples_budget/templates/understanding-the-budget.html
+++ b/peoples_budget/templates/understanding-the-budget.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div class="understanding_the_budget">
         <div id="header-info">
-            <h1>Here's what you need to know about the 2023 General Budget</h1>
+            <h1>Here's what you need to know about the 2025 General Budget</h1>
             <h2>A guide and glossary created by the <a href="https://cleveland.documenters.org/">Cleveland Documenters</a></h2>
         </div>
 <p>Cleveland is required by law each year to pass a balanced budget, meaning the city can&rsquo;t spend more money than it takes in.&nbsp;</p>
@@ -18,14 +18,16 @@
 <p>⮕ At the end of the year, council decides whether to redistribute or save any money that was not spent.&nbsp;</p>
 <p>This year, the city will hold its budget hearings and deliberations in Council Chambers at City Hall. These hearings will also be livestreamed on <a href="https://www.clevelandohio.gov/city-hall/office-mayor/tv20">TV20</a> and on <a href="https://www.youtube.com/user/ClevelandCityCouncil">Cleveland City Council&rsquo;s YouTube channel.</a></p>
 <p><br /><br /></p>
-<p><strong>What is the purpose of the budget?</strong></p>
+<h2><strong>What is the purpose of the budget?</strong></h2>
 <p>The budget tells residents what money the city is collecting and how it is being spent. The budget also clarifies what city leaders&rsquo; priorities are. The Budget Book breaks the spending and priorities down by department (the highest level of organization) and by division (different sections of the departments.) City departments have directors and divisions have commissioners.&nbsp;</p>
 <p>In the Budget Book, you can see priorities laid out for each department.&nbsp;</p>
 <p>Find the <a href="https://www.clevelandohio.gov/sites/clevelandohio/files/finance-docs/documents/2025%20City%20of%20Cleveland%20Mayor's%20Estimate_FINAL.pdf">current Mayor&rsquo;s Estimate for the budget</a>.</p>
 <p>Find the <a href="https://www.clevelandohio.gov/sites/clevelandohio/files/cd/2024-25%20Annual%20Action%20Plan%20Draft.pdf">Community Development Block Grant Fund budget</a>.</p>
 <p><br /><br /></p>
-<p><strong>Find past Budget Books:&nbsp;</strong></p>
+<h2><strong>Find past Budget Books:&nbsp;</strong></h2>
 <ul>
+    <li><a href="https://clevelandohio.gov/sites/clevelandohio/files/finance-docs/2024Budget.pdf">2024 Budget Book</a></li>
+    <li><a href="https://www.clevelandohio.gov/sites/clevelandohio/files/finance-docs/documents/2023BudgetBook.pdf">2023 Budget Book</a></li>
 <li><a href="https://www.clevelandohio.gov/sites/clevelandohio/files/finance-docs/documents/2022BudgetBook.pdf">2022 Budget Book</a></li>
 <li><a href="https://www.clevelandohio.gov/sites/clevelandohio/files/finance-docs/documents/2021BudgetBook.pdf">2021 Budget Book</a></li>
 <li><a href="https://www.clevelandohio.gov/sites/clevelandohio/files/finance-docs/documents/2020BudgetBook.pdf">2020 Budget Book</a></li>
@@ -33,23 +35,19 @@
 <li><a href="https://www.clevelandohio.gov/sites/clevelandohio/files/finance-docs/documents/2018BudgetBook.pdf">2018 Budget Book</a></li>
 </ul>
 <br /><br />
-<p><strong>How is the budget organized?</strong></p>
+<h2><strong>How is the budget organized?</strong></h2>
 <ul>
 <li>The two main parts are the Operating Budget and the Capital Budget. The Operating Budget is the money spent on things such as employees and supplies. The Capital Budget includes larger investments in buildings or street lights.&nbsp;</li>
-</ul>
-<ul>
 <li>The money that is spent comes from several buckets. The major funds include: General Fund, Special Revenue Funds, Enterprise Funds and the Agency Fund. Find the <a href="https://drive.google.com/drive/folders/1fljcArYE5vUPXQo4l7L3RI19CjG_WQrf?usp=sharing">glossary</a> for definitions of these terms.&nbsp;</li>
-</ul>
-<ul>
 <li>Money that the city receives from most federal and state grants is not included in the city budget funds because those grants are managed following different rules and often on a different schedule, or fiscal year.&nbsp;</li>
 </ul>
-<p><strong>Where does the money come from?</strong></p>
+<h2><strong>Where does the money come from?</strong></h2>
 <p>Cleveland collects money in the form of taxes: income taxes from paychecks of people who work and/or live in the city, and taxes and fees from businesses such as &ldquo;bed&rdquo; taxes from hotel rooms.&nbsp;</p>
-<p><strong>What is City Council's role?</strong></p>
+<h2><strong>What is City Council's role?</strong></h2>
 <p>The legislative body reviews, amends &ndash; changes &ndash; and approves the city budget.&nbsp;</p>
 <p><br /><br /></p>
-<p><strong>Budget terms:</strong></p>
-<p>Take a look at our<a href="https://drive.google.com/drive/folders/1fljcArYE5vUPXQo4l7L3RI19CjG_WQrf?usp=sharing"> glossary of words used in budget hearings</a>&nbsp;</p>
+<h2><strong>Budget terms:</strong></h2>
+<p>Take a look at the <a href="https://drive.google.com/drive/folders/1fljcArYE5vUPXQo4l7L3RI19CjG_WQrf?usp=sharing"> glossary of words used in budget hearings</a>courtesy of the Cleveland Documenters.</p>
 
 <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vQN6GnpNS2BLCwSjPLQ9tiX9L2_q2r3bwKj8OzdvheQEiNYyd65gHZSD3nm69jPoBDfhe_04VB3XjLE/embed?start=false&loop=true&delayms=3000" frameborder="0" width="480" height="299" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
         <div id="understanding_the_budget_legend"></div>

--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 def home(request):
-    with open(os.path.join(settings.BASE_DIR, 'static/data/2024-mayors-estimate-fullgeneralfund.json')) as file:
+    with open(os.path.join(settings.BASE_DIR, 'static/data/2025-mayors-estimate-fullgeneralfund.json')) as file:
         json_file = json.load(file)
 
     return render(request, 'home.html', {
@@ -31,7 +31,7 @@ def home(request):
 
 def change_budget(request):
     """Collect user budget data"""
-    with open(os.path.join(settings.BASE_DIR, 'static/data/2024-mayors-estimate-fullgeneralfund.json')) as file:
+    with open(os.path.join(settings.BASE_DIR, 'static/data/2025-mayors-estimate-fullgeneralfund.json')) as file:
         json_file = json.load(file)
 
     # Add hidden field to store user budget data
@@ -105,7 +105,7 @@ def store_data(request):
 
 def view_budget(request, budget_id):
     """View a saved budget given budget_id"""
-    with open(os.path.join(settings.BASE_DIR, 'static/data/2024-mayors-estimate-fullgeneralfund.json')) as file:
+    with open(os.path.join(settings.BASE_DIR, 'static/data/2025-mayors-estimate-fullgeneralfund.json')) as file:
         mayor_json_file = json.load(file)
 
     try:
@@ -151,7 +151,7 @@ def send_email(submitter_email, id):
         data={"from": "Refund Cleveland <info@refundcleveland.com>",
               "to": [submitter_email],
               "subject": "Your Cleveland Budget Proposal",
-              "text": f"Thank you for submitting your budget proposal for the 2024 City of Cleveland Budget!\n"
+              "text": f"Thank you for submitting your budget proposal for the 2025 City of Cleveland Budget!\n"
                       f"View or share your budget here: https://www.refundcleveland.com/{id}/view\n\n"
                       f"Brought to you by your friends at Open Cleveland! https://www.opencleveland.org"})
 

--- a/static/js/change-budget.js
+++ b/static/js/change-budget.js
@@ -48,7 +48,7 @@
     // the user is manipulating
     d3.select("#header-info").append("div")
         .html(function () {
-            return `<p>Refund Cleveland is collecting public feedback about how <strong>$${add_commas(data.total)}</strong> should be dispersed between the categories below (the full <strong>$${add_commas(data.full_total)}</strong> minus the <strong>$${add_commas(other_category.total)}</strong> "Administration, Law, and Other" category in our <a href="/">&laquo; simplified view of Mayor Bibb's 2024 budget proposal</a>).</p>`
+            return `<p>Refund Cleveland is collecting public feedback about how <strong>$${add_commas(data.total)}</strong> should be dispersed between the categories below (the full <strong>$${add_commas(data.full_total)}</strong> minus the <strong>$${add_commas(other_category.total)}</strong> "Administration, Law, and Other" category in our <a href="/">&laquo; simplified view of Mayor Bibb's 2025 budget proposal</a>).</p>`
         });
 
     const MULTIPLIER = 2,  // add height to bars


### PR DESCRIPTION
This is the remainder of the updates for 2025: 

- updating mentions of 2024 to 2025; 
- loads the 2025 budget instead of the 2024 budget as well; 

also uses heading level 2 instead of paragraph elements for some content; the headings are more appropriate from a semantic html perspective and are better for accessibility purposes .
