### PR TITLE
Refactor address geocoding to use Nominatim API and clean up code

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ If you need to install PostgreSQL, please follow these steps:
 Copy and rename **local_settings_template.py** to **local_settings.py**, and fill in environmental variables:
 
 `SECRET_KEY` -- Django’s Secret Key used by the project
-`GOOGLE_API_KEY` -- Used for Google's Civic Information API to map Address to Political Ward
 `MAILGUN_API_KEY` -- Used for the Mailgun API that sends out emails when a user submits a budget
 
 `DATABASES` -- map of parameters to define the connection to a database.  In prod, we are using a postgres db hosted on heroku, and the connection is injected there via config vars.  For local versions, enter the information you used when creating the database.  Example:

--- a/local_settings_template.py
+++ b/local_settings_template.py
@@ -1,7 +1,6 @@
 # rename to local_settings.py
 DEBUG="TRUE"
 SECRET_KEY="ENTER KEY HERE" # Django secret key
-GOOGLE_API_KEY="ENTER KEY HERE" #Geocode Earth Api Key
 MAILGUN_API_KEY="ENTER KEY HERE"
 
 # these are rolling credentials, and may need to be updated occasionally

--- a/peoples_budget/templates/submit-budget.html
+++ b/peoples_budget/templates/submit-budget.html
@@ -12,7 +12,7 @@
     <p>Don't know your political ward? No problem! You can look it up on Cleveland's website <a href="https://clevelandcitycouncil.org/find-my-ward" target="_blank" rel="noopener noreferrer">find-my-ward</a>
         or we can look it up for you if you enter your address here:</p>
     <label for="id_address">Address:</label><br>
-    <input type="text" id="id_address"/><br><br>
+    <input type="text" id="id_address"/><br><small>Search by <a href="https://nominatim.org">Nominatim</a> | ©<a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, <a href="https://opendatacommons.org/licenses/odbl/">ODbL</a></small><br>
     <input type="button" onclick="lookup_address()" value="Find Ward" id="submit_btn">
 
 {% endblock content %}

--- a/peoples_budget/templates/submit-budget.html
+++ b/peoples_budget/templates/submit-budget.html
@@ -9,12 +9,11 @@
         <input type="submit" value="Submit Your Budget" id="submit_btn">
     </form>
 
-    <p>Don't know your political ward? No problem! You can look it up on Cleveland's website <a href="https://clevelandcitycouncil.org/find-my-ward" target="_blank" rel="noopener noreferrer">find-my-ward</a> 
-        <!-- comment out find-my-ward form for now while alternative solution is built -->
-        <!-- or we can look it up for you if you enter your address here:</p>
+    <p>Don't know your political ward? No problem! You can look it up on Cleveland's website <a href="https://clevelandcitycouncil.org/find-my-ward" target="_blank" rel="noopener noreferrer">find-my-ward</a>
+        or we can look it up for you if you enter your address here:</p>
     <label for="id_address">Address:</label><br>
     <input type="text" id="id_address"/><br><br>
-    <input type="button" onclick="lookup_address()" value="Find Ward" id="submit_btn"> -->
+    <input type="button" onclick="lookup_address()" value="Find Ward" id="submit_btn">
 
 {% endblock content %}
 

--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -13,7 +13,6 @@ import requests
 try:
     from local_settings import *
 except ImportError:
-    GOOGLE_API_KEY = os.getenv('GOOGLE_API_KEY')
     MAILGUN_API_KEY = os.getenv('MAILGUN_API_KEY')
     pass
 

--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -155,6 +155,16 @@ def send_email(submitter_email, id):
                       f"View or share your budget here: https://www.refundcleveland.com/{id}/view\n\n"
                       f"Brought to you by your friends at Open Cleveland! https://www.opencleveland.org"})
 
+def geocode_address(query):
+    req = urllib.request.Request(
+            query, headers={'User-Agent': 'RefundCleveland/1.0'}
+        )
+    nom_json = json.load(urllib.request.urlopen(req))
+    lat = nom_json[0]["lat"]
+    lon = nom_json[0]["lon"]
+    arcgis_query = f'https://services3.arcgis.com/dty2kHktVXHrqO8i/arcgis/rest/services/Cleveland_Wards_1_2_25_Topocleaned_pop20/FeatureServer/0/query?geometry={lon},{lat}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=ward&f=json'
+    
+    return json.load(urllib.request.urlopen(arcgis_query))
 
 def privacy_policy(request):
     return render(request, 'privacy-policy.html', {

--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from peoples_budget import models
 import uuid
 import urllib, urllib.request
-import datetime
+import time
 import requests
 
 try:
@@ -121,7 +121,7 @@ def view_budget(request, budget_id):
         'mayor_json_data': mayor_json_file
     })
 
-# TODO(DevLoggith): update this function to use cleveland open data's "City of Cleveland Wards (2026)" dataset along with nominatim geocoding
+
 def lookup_address(request):
     body = json.loads(request.body)
     address = body['address'] + ' cleveland ohio'
@@ -154,10 +154,12 @@ def send_email(submitter_email, id):
                       f"View or share your budget here: https://www.refundcleveland.com/{id}/view\n\n"
                       f"Brought to you by your friends at Open Cleveland! https://www.opencleveland.org"})
 
+
 def geocode_address(query):
     req = urllib.request.Request(
             query, headers={'User-Agent': 'RefundCleveland/1.0'}
         )
+    time.sleep(1) # add 1 second wait as per Nominatim's rate limits
     nom_json = json.load(urllib.request.urlopen(req))
     lat = nom_json[0]["lat"]
     lon = nom_json[0]["lon"]
@@ -165,11 +167,13 @@ def geocode_address(query):
     
     return json.load(urllib.request.urlopen(arcgis_query))
 
+
 def privacy_policy(request):
     return render(request, 'privacy-policy.html', {
         'home': True,
         'body_classes': 'privacy-policy'
     })
+
 
 def understanding_the_budget(request):
     return render(request, 'understanding-the-budget.html', {

--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -124,10 +124,10 @@ def view_budget(request, budget_id):
 # TODO(DevLoggith): update this function to use cleveland open data's "City of Cleveland Wards (2026)" dataset along with nominatim geocoding
 def lookup_address(request):
     body = json.loads(request.body)
-    address = body['address'] + ' Cleveland Ohio'
+    address = body['address'] + ' cleveland ohio'
 
-    query = "https://www.googleapis.com/civicinfo/v2/divisionsByAddress?address=" + urllib.parse.quote_plus(
-        address) + "&key=" + GOOGLE_API_KEY
+    nom_query = "https://nominatim.openstreetmap.org/search?q=" + urllib.parse.quote_plus(
+        address) + "&format=json&limit=1&countrycodes=us"
 
     try:
         json_response = json.load(urllib.request.urlopen(query))

--- a/peoples_budget/views.py
+++ b/peoples_budget/views.py
@@ -130,14 +130,13 @@ def lookup_address(request):
         address) + "&format=json&limit=1&countrycodes=us"
 
     try:
-        json_response = json.load(urllib.request.urlopen(query))
+        ward_json  = geocode_address(nom_query)
+        ward = ward_json["features"][0]["attributes"]["Ward"]
 
-        ward = [x.split(':')[-1] for x in json_response['divisions'] if 'ward' in x]
-        if ward:
-            ward = ward[0]
-            return render(request, 'lookup_address.html', {
-                'ward': ward
-            })
+        return render(request, 'lookup_address.html', {
+            'ward': ward
+        })
+
     except:
         return render(request, 'lookup_address.html', {
             'ward': None

--- a/refund_cleveland/settings.py
+++ b/refund_cleveland/settings.py
@@ -16,7 +16,6 @@ try:
     from local_settings import *
 except ImportError:
     SECRET_KEY = os.getenv('SECRET_KEY')
-    GOOGLE_API_KEY = os.getenv('GOOGLE_API_KEY')
     pass
 import django_heroku
 


### PR DESCRIPTION
This PR:
- Switches from the Google Civic info API to Nominatim (geolocation) + ClevelandGIS (up to date ward data)
- Creates an attribution to Nominatim and OSM below the find-my-ward text input as per their usage policy
- Cleans up:
  - Unused `datetime` import
  - `GOOGLE_API_KEY` env variables & imports

Below you can see a screenshot of what the attribution text & links looks like.
<img width="525" alt="Screenshot 2026-03-27 121535" src="https://github.com/user-attachments/assets/0eafebed-154e-44a8-b648-eff3e70be3d0" />
I've tested it manually with a handful of different address from around the city and verified that addresses inside of a ward return the proper ward number, as well as addresses outside of any ward return `{ "ward" : "None"}`

Closes #143 